### PR TITLE
[DOC]: Update React Best Practices section

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -5,12 +5,13 @@
 - [Think in React](https://react.dev/learn/thinking-in-react)
 - Use only Function Components, [no more Class Component](https://react.dev/reference/react/Component#alternatives)
 - Use custom hooks instead of HOC, replace withFoo by useFoo
+- Follow the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
 - Use composition
 - Use slots
 - Use "as" prop to override an `Element`
 - Seperate the smart and dumb component
 - Keep state as local as possible.
-- Derive state, don't sync state, (you might not need an effect)[https://react.dev/learn/you-might-not-need-an-effect]
+- Derive state, don't sync state, [you might not need an effect](https://react.dev/learn/you-might-not-need-an-effect)
 - Prefer state enums instead of booleans
 - Use Storybook to code your components in isolation and enforce the separation of concern design pattern
 - Use React Testing Library for testing your components and mimic users effects
@@ -43,6 +44,7 @@ State Machine :
 
 Deprecated :
 
+- [Redux Toolkit (RTK)](https://redux-toolkit.js.org/introduction/why-rtk-is-redux-today) – Still actively maintained and officially recommended for Redux. However, we don't recommend it for new projects due to simpler alternatives like Zustand or Jotai.
 - Redux & redux-saga
 
 ## Hooks


### PR DESCRIPTION
# Pull Request Template

## ✨ Title
[DOC]: Add Redux Toolkit to state management options and React Hooks rules to best practices

## 📄 Description

* Redux Toolkit (RTK) Add popular to State Management Options like RTK in the "deprecated" section
  - RTK is actively maintained and up-to-date: It's officially maintained by the Redux team and represents the modern, recommended approach to using Redux. It's a viable solution as long as you don't abuse it :) 
  - Technical accuracy: It would be disrespectful and technically incorrect to omit Redux Toolkit or treat Redux as deprecated, which it is not.
  - Industry relevance: Redux remains widely used in the industry, and RTK solves the historical verbosity and complexity issues of classic Redux.

* Rules of Hooks Addition to React Best Practices


